### PR TITLE
Run Elasticsearch in the production-like configuration

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -25,3 +25,10 @@ services:
       - ./nginx/default.conf:/etc/nginx/conf.d/default.conf
     depends_on:
       - app
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.6.1
+    ports:
+      - "9200:9200"
+    environment:
+      - discovery.type=single-node


### PR DESCRIPTION
Ported from `docker-compose.dev.yml`